### PR TITLE
Dataset load robustness

### DIFF
--- a/src/main/kotlin/org/hhu/examine/data/model/Network.kt
+++ b/src/main/kotlin/org/hhu/examine/data/model/Network.kt
@@ -50,6 +50,6 @@ private class SimpleNetwork(
 internal fun networkToGraph(network: Network): UndirectedGraph<NetworkNode, NetworkLink> {
     val graph = Pseudograph<NetworkNode, NetworkLink>(NetworkLink::class.java)
     network.nodes.rows.forEach { graph.addVertex(it) }
-    network.links.rows.forEach { graph.addEdge(it.source, it.target, it) }
+    network.links.rows.forEach { if (!graph.containsEdge(it.source, it.target)) graph.addEdge(it.source, it.target, it) }
     return graph
 }

--- a/src/main/kotlin/org/hhu/examine/main/nodelinkcontour/NetworkElementLayer.kt
+++ b/src/main/kotlin/org/hhu/examine/main/nodelinkcontour/NetworkElementLayer.kt
@@ -34,9 +34,9 @@ internal class NetworkElementLayer<E, R : Node>(
 
     private fun onHighlightedElementsChange(change: SetChangeListener.Change<out E>) {
         if (change.wasAdded()) {
-            representations[change.elementAdded]!!.styleClass.add(ELEMENT_HIGHLIGHTED_STYLE)
+            representations[change.elementAdded]?.styleClass?.add(ELEMENT_HIGHLIGHTED_STYLE)
         } else if (change.wasRemoved()) {
-            representations[change.elementRemoved]!!.styleClass.remove(ELEMENT_HIGHLIGHTED_STYLE)
+            representations[change.elementRemoved]?.styleClass?.remove(ELEMENT_HIGHLIGHTED_STYLE)
         }
     }
 


### PR DESCRIPTION
- Handle duplicate interactions (ignoring direction);
- Ignore annotation members that do not have a graphical representation.